### PR TITLE
update S3 sync command to copy frontend distribution files

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -18,4 +18,4 @@ jobs:
           aws-region: eu-west-1
 
       - name: Sync to S3
-        run: aws s3 sync . s3://watkostmijninterieur
+        run: aws s3 cp apps/frontend/dist s3://watkostmijninterieur


### PR DESCRIPTION
This pull request includes a change to the deployment workflow configuration in the `.github/workflows/deployment.yaml` file. The change modifies the S3 synchronization command to copy the contents of the `apps/frontend/dist` directory instead of syncing the entire repository.

Deployment workflow update:

* [`.github/workflows/deployment.yaml`](diffhunk://#diff-259f2188de53828dcb003900d2a84cfd00a909870115a6e14ddc019e96255087L21-R21): Changed the `aws s3 sync` command to `aws s3 cp` to only copy the `apps/frontend/dist` directory to the S3 bucket `watkostmijninterieur`.