### PR TITLE
update GitHub Actions workflow to assume role for AWS access and add …

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -8,14 +8,16 @@ on:
       - dev
 
 env:
+  AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
   AWS_REGION: ${{ secrets.AWS_REGION }}
+  S3_BUCKET: ${{ secrets.S3_BUCKET }}
 
 permissions:
   id-token: write
   contents: read
 
 jobs:
-  AssumeRoleAndCallIdentity:
+  Deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -24,9 +26,9 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v3
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
           role-session-name: GitHub_to_AWS_via_FederatedOIDC
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Build Frontend
         run: |
@@ -36,4 +38,4 @@ jobs:
 
       - name: Deploy to S3
         run: |
-          aws s3 sync apps/frontend/dist s3://${{ secrets.S3_BUCKET }} --delete
+          aws s3 sync apps/frontend/dist s3://${{ env.S3_BUCKET }} --delete

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -3,27 +3,41 @@ on:
   push:
     branches:
       - dev
+  pull_request:
+    branches:
+      - dev
+
+env:
+  AWS_REGION: "eu-west-1"
+
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
-  sync:
+  AssumeRoleAndCallIdentity:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: arn:aws:iam::515966496575:oidc-provider/token.actions.githubusercontent.com
+          role-session-name: GitHub_to_AWS_via_FederatedOIDC
           aws-region: eu-west-1
 
-      - name: Build Frontend
+      - name: Sts GetCallerIdentity
         run: |
-          cd apps/frontend
-          yarn install
-          yarn build
+          aws sts get-caller-identity
 
-      - name: Sync Files to S3
-        run: |
-          aws s3 sync apps/frontend/dist s3://watkostmijninterieur --delete
+      # - name: Build Frontend
+      #   run: |
+      #     cd apps/frontend
+      #     yarn install
+      #     yarn build
+
+      # - name: Sync Files to S3
+      #   run: |
+      #     aws s3 sync apps/frontend/dist s3://watkostmijninterieur --delete

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -8,7 +8,7 @@ on:
       - dev
 
 env:
-  AWS_REGION: "eu-west-1"
+  AWS_REGION: ${{ secrets.AWS_REGION }}
 
 permissions:
   id-token: write
@@ -22,22 +22,18 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           role-session-name: GitHub_to_AWS_via_FederatedOIDC
-          aws-region: eu-west-1
+          aws-region: ${{ secrets.AWS_REGION }}
 
-      - name: Sts GetCallerIdentity
+      - name: Build Frontend
         run: |
-          aws sts get-caller-identity
+          cd apps/frontend
+          yarn install
+          yarn build
 
-      # - name: Build Frontend
-      #   run: |
-      #     cd apps/frontend
-      #     yarn install
-      #     yarn build
-
-      # - name: Sync Files to S3
-      #   run: |
-      #     aws s3 sync apps/frontend/dist s3://watkostmijninterieur --delete
+      - name: Deploy to S3
+        run: |
+          aws s3 sync apps/frontend/dist s3://${{ secrets.S3_BUCKET }} --delete

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          role-to-assume: arn:aws:iam::515966496575:role/GitHubAction-AssumeRoleWithAction
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           role-session-name: GitHub_to_AWS_via_FederatedOIDC
           aws-region: eu-west-1
 

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          role-to-assume: arn:aws:iam::515966496575:oidc-provider/token.actions.githubusercontent.com
+          role-to-assume: arn:aws:iam::515966496575:role/GitHubAction-AssumeRoleWithAction
           role-session-name: GitHub_to_AWS_via_FederatedOIDC
           aws-region: eu-west-1
 


### PR DESCRIPTION
This pull request includes several changes to the GitHub Actions deployment workflow, primarily focusing on adding environment configurations, updating job names, and modifying AWS credential configuration.

Key changes in the deployment workflow:

* Added support for `pull_request` events on the `dev` branch and environment variables for AWS region. (`.github/workflows/deployment.yaml`)
* Updated job name from `sync` to `AssumeRoleAndCallIdentity` and changed the action version for `actions/checkout` from `v3` to `v4`. (`.github/workflows/deployment.yaml`)
* Configured AWS credentials to assume a role using OIDC instead of using access keys. (`.github/workflows/deployment.yaml`)
* Commented out the steps for building the frontend and syncing files to S3. (`.github/workflows/deployment.yaml`)…pull request trigger