### PR TITLE
update deployment workflow to trigger on pull requests for dev and ma…

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -1,6 +1,6 @@
 name: Deploy Website
 on:
-  push:
+  pull_request:
     branches:
       - dev
       - main
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   dev:
-    if: github.ref == 'refs/heads/dev'
+    if: github.event_name == 'pull_request' && github.base_ref == 'dev'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -42,7 +42,7 @@ jobs:
           aws s3 sync apps/frontend/dist s3://${{ env.S3_BUCKET_DEV }} --delete
 
   wait-for-approval:
-    if: github.ref == 'refs/heads/main'
+    if: github.event_name == 'pull_request' && github.base_ref == 'main'
     runs-on: ubuntu-latest
     environment: production
     steps:
@@ -50,7 +50,7 @@ jobs:
         run: echo "Deployment waiting for manual approval"
 
   prod:
-    if: github.ref == 'refs/heads/main'
+    if: github.event_name == 'pull_request' && github.base_ref == 'main'
     runs-on: ubuntu-latest
     needs: wait-for-approval
     environment: production


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow for deploying the website. The modifications focus on triggering deployments based on pull requests rather than direct pushes to specific branches.

Changes to deployment triggers:

* [`.github/workflows/deployment.yaml`](diffhunk://#diff-259f2188de53828dcb003900d2a84cfd00a909870115a6e14ddc019e96255087L3-R3): Changed the event trigger from `push` to `pull_request` for the deployment workflow.

Conditional job execution based on pull request events:

* [`.github/workflows/deployment.yaml`](diffhunk://#diff-259f2188de53828dcb003900d2a84cfd00a909870115a6e14ddc019e96255087L21-R21): Updated the condition for the `dev` job to check if the event is a pull request targeting the `dev` branch.
* [`.github/workflows/deployment.yaml`](diffhunk://#diff-259f2188de53828dcb003900d2a84cfd00a909870115a6e14ddc019e96255087L45-R53): Updated the condition for the `wait-for-approval` job to check if the event is a pull request targeting the `main` branch.
* [`.github/workflows/deployment.yaml`](diffhunk://#diff-259f2188de53828dcb003900d2a84cfd00a909870115a6e14ddc019e96255087L45-R53): Updated the condition for the `prod` job to check if the event is a pull request targeting the `main` branch.…in branches