### PR TITLE
remove manual approval step from deployment workflow, because we do t…

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -44,18 +44,9 @@ jobs:
         run: |
           aws s3 sync apps/frontend/dist s3://${{ env.S3_BUCKET_DEV }} --delete
 
-  wait-for-approval:
-    if: github.event_name == 'pull_request' && github.base_ref == 'main'
-    runs-on: ubuntu-latest
-    environment: production
-    steps:
-      - name: Wait for manual approval
-        run: echo "Deployment waiting for manual approval"
-
   prod:
     if: github.event_name == 'pull_request' && github.base_ref == 'main'
     runs-on: ubuntu-latest
-    needs: wait-for-approval
     environment: production
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
This pull request includes a change to the deployment workflow configuration in the `.github/workflows/deployment.yaml` file. The most important change is the removal of the manual approval step for production deployments.

Changes to deployment workflow:

* [`.github/workflows/deployment.yaml`](diffhunk://#diff-259f2188de53828dcb003900d2a84cfd00a909870115a6e14ddc019e96255087L47-L58): Removed the `wait-for-approval` job, which included a step for waiting for manual approval before proceeding with the production deployment.…his at the prod job