### PR TITLE
update CORS headers in lambdaHandler to allow all origins

### DIFF
--- a/apps/backend/src/handlers/lambdaHandler.ts
+++ b/apps/backend/src/handlers/lambdaHandler.ts
@@ -46,8 +46,7 @@ export const handler = async (
       return {
         statusCode: 400,
         headers: {
-          "Access-Control-Allow-Origin": "http://localhost:3000",
-          "Access-Control-Allow-Headers": "Content-Type",
+          "Access-Control-Allow-Origin": "*",
           "Access-Control-Allow-Methods": "POST, OPTIONS",
           "Content-Type": "application/json",
         },


### PR DESCRIPTION
This pull request includes a change to the CORS policy in the `lambdaHandler.ts` file to allow requests from any origin.

* [`apps/backend/src/handlers/lambdaHandler.ts`](diffhunk://#diff-fb05773b6b20f3dd6838abb0c1d5db247a61f714106bf87ebc0b4f1321248f1dL49-R49): Modified the `Access-Control-Allow-Origin` header to accept requests from any origin by changing its value to `"*"`.